### PR TITLE
Update multiseller aggregation logic

### DIFF
--- a/src/public/application/libraries/CalculoFrete.php
+++ b/src/public/application/libraries/CalculoFrete.php
@@ -4162,7 +4162,7 @@ class CalculoFrete {
             ];
             
             $allShippingMethods = [];
-            $hasAnySuccess = false;
+            $allSuccessful = true;
             
             // Processar resultados de cada seller
             foreach ($results as $seller => $result) {
@@ -4174,7 +4174,6 @@ class CalculoFrete {
                 ];
                 
                 if ($result['success'] && isset($result['data']['shipping_methods'])) {
-                    $hasAnySuccess = true;
                     $aggregatedData['summary']['successful_sellers']++;
                     
                     $sellerData['shipping_methods'] = $result['data']['shipping_methods'];
@@ -4213,6 +4212,7 @@ class CalculoFrete {
                 } else {
                     $aggregatedData['summary']['failed_sellers']++;
                     $sellerData['error'] = $result['data']['message'] ?? 'Erro desconhecido';
+                    $allSuccessful = false;
                 }
                 
                 $aggregatedData['sellers'][] = $sellerData;
@@ -4230,10 +4230,10 @@ class CalculoFrete {
             }
             
             // Determinar sucesso geral
-            $aggregatedData['success'] = $hasAnySuccess;
-            
-            if (!$hasAnySuccess) {
-                $aggregatedData['message'] = 'Nenhuma cotação bem-sucedida encontrada para os sellers';
+            $aggregatedData['success'] = $allSuccessful;
+
+            if (!$allSuccessful) {
+                $aggregatedData['message'] = 'Não há cotação de frete disponível para este carrinho';
             }
             
             // Log para debugging

--- a/src/public/tests/Unit/CalculoFreteAggregationTest.php
+++ b/src/public/tests/Unit/CalculoFreteAggregationTest.php
@@ -1,0 +1,77 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class CalculoFreteAggregationTest extends TestCase
+{
+    private function callPrivateMethod($object, $method, array $args = [])
+    {
+        $ref = new ReflectionClass($object);
+        $m = $ref->getMethod($method);
+        $m->setAccessible(true);
+        return $m->invokeArgs($object, $args);
+    }
+
+    public function testAggregateReturnsSuccessWhenAllSellersSucceed()
+    {
+        $ref = new ReflectionClass(CalculoFrete::class);
+        $instance = $ref->newInstanceWithoutConstructor();
+
+        $results = [
+            'seller1' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 10, 'deadline' => 1]
+                    ],
+                    'seller_execution_time' => 0.1,
+                    'seller_execution_mode' => 'test'
+                ]
+            ],
+            'seller2' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'B', 'price' => 15, 'deadline' => 2]
+                    ],
+                    'seller_execution_time' => 0.2,
+                    'seller_execution_mode' => 'test'
+                ]
+            ]
+        ];
+
+        $result = $this->callPrivateMethod($instance, 'aggregateMultisellerResults', [$results, 0.5]);
+        $this->assertTrue($result['success']);
+        $this->assertTrue($result['data']['success']);
+        $this->assertArrayNotHasKey('message', $result['data']);
+    }
+
+    public function testAggregateFailsWhenAnySellerFails()
+    {
+        $ref = new ReflectionClass(CalculoFrete::class);
+        $instance = $ref->newInstanceWithoutConstructor();
+
+        $results = [
+            'seller1' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 10, 'deadline' => 1]
+                    ],
+                    'seller_execution_time' => 0.1,
+                    'seller_execution_mode' => 'test'
+                ]
+            ],
+            'seller2' => [
+                'success' => false,
+                'data' => [
+                    'message' => 'error'
+                ]
+            ]
+        ];
+
+        $result = $this->callPrivateMethod($instance, 'aggregateMultisellerResults', [$results, 0.5]);
+        $this->assertFalse($result['success']);
+        $this->assertFalse($result['data']['success']);
+        $this->assertSame('Não há cotação de frete disponível para este carrinho', $result['data']['message']);
+    }
+}


### PR DESCRIPTION
## Summary
- fix multiseller aggregation success criteria
- fail overall when any seller fails
- add unit tests covering aggregation logic

## Testing
- `./vendor/bin/phpunit tests/Unit/CalculoFreteAggregationTest.php -c phpunit.xml` *(fails: PHPUnit\Framework\ExceptionWrapper::originalException(): Implicitly marking parameter $exceptionToStore as nullable is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_6873c94ccbdc8328b419062e833e4183