### PR TITLE
Implement multiseller aggregation rule

### DIFF
--- a/src/public/tests/Unit/CalculoFreteAggregationTest.php
+++ b/src/public/tests/Unit/CalculoFreteAggregationTest.php
@@ -1,5 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
+define('BASEPATH', __DIR__);
+require_once __DIR__ . '/../../application/libraries/CalculoFrete.php';
 
 class CalculoFreteAggregationTest extends TestCase
 {
@@ -74,4 +76,77 @@ class CalculoFreteAggregationTest extends TestCase
         $this->assertFalse($result['data']['success']);
         $this->assertSame('Não há cotação de frete disponível para este carrinho', $result['data']['message']);
     }
+
+    public function testChosenShippingByLowestPrice()
+    {
+        $ref = new ReflectionClass(CalculoFrete::class);
+        $instance = $ref->newInstanceWithoutConstructor();
+        $instance->setMultisellerParams(['rule' => 'menor_preco']);
+
+        $results = [
+            'seller1' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 10, 'deadline' => 5],
+                        ['name' => 'B', 'price' => 8, 'deadline' => 7],
+                    ],
+                    'seller_execution_time' => 0.1,
+                    'seller_execution_mode' => 'test'
+                ]
+            ],
+            'seller2' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 12, 'deadline' => 4],
+                        ['name' => 'B', 'price' => 6, 'deadline' => 6],
+                    ],
+                    'seller_execution_time' => 0.2,
+                    'seller_execution_mode' => 'test'
+                ]
+            ]
+        ];
+
+        $result = $this->callPrivateMethod($instance, 'aggregateMultisellerResults', [$results, 0.5]);
+        $this->assertSame('B', $result['data']['chosen_shipping']['name']);
+        $this->assertSame(14.0, $result['data']['chosen_shipping']['total_price']);
+    }
+
+    public function testChosenShippingByShortestDeadline()
+    {
+        $ref = new ReflectionClass(CalculoFrete::class);
+        $instance = $ref->newInstanceWithoutConstructor();
+        $instance->setMultisellerParams(['rule' => 'menor_prazo']);
+
+        $results = [
+            'seller1' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 10, 'deadline' => 5],
+                        ['name' => 'B', 'price' => 8, 'deadline' => 7],
+                    ],
+                    'seller_execution_time' => 0.1,
+                    'seller_execution_mode' => 'test'
+                ]
+            ],
+            'seller2' => [
+                'success' => true,
+                'data' => [
+                    'shipping_methods' => [
+                        ['name' => 'A', 'price' => 12, 'deadline' => 4],
+                        ['name' => 'B', 'price' => 6, 'deadline' => 6],
+                    ],
+                    'seller_execution_time' => 0.2,
+                    'seller_execution_mode' => 'test'
+                ]
+            ]
+        ];
+
+        $result = $this->callPrivateMethod($instance, 'aggregateMultisellerResults', [$results, 0.5]);
+        $this->assertSame('A', $result['data']['chosen_shipping']['name']);
+        $this->assertSame(5, $result['data']['chosen_shipping']['max_deadline']);
+    }
 }
+


### PR DESCRIPTION
## Summary
- add multiseller parameters property and setter
- aggregate results using rule menor_preco or menor_prazo
- log chosen aggregation rule and method
- test chosen shipping by price or deadline

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `php -d error_reporting=0 vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Unit/CalculoFreteAggregationTest.php` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6873d8700f2883289cb8caa669c464f0