### PR TITLE
Add quote lookup tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ This repository contains a container setup for the application.
   ```json
   {"lowest_price": "Normal", "lowest_deadline": "Expressa"}
   ```
+
+## Manual Testing
+
+To manually verify quote lookups and order splitting:
+1. Insert a row into the `quotes_ship` table with the expected marketplace, ZIP code, SKUs and cost.
+2. Create an order that matches the same parameters.
+3. Run the batch `TinyInvoice` process that contracts freight.
+4. Confirm the process fetches the stored quote and splits the order accordingly in the marketplace dashboard.

--- a/src/public/tests/Fakes/FakeQuotesDbHandler.php
+++ b/src/public/tests/Fakes/FakeQuotesDbHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+class FakeQuotesDbHandler extends FakeDbHandler
+{
+    private $row;
+    public function __construct(array $row = [])
+    {
+        $this->row = $row;
+    }
+
+    public function query($sql, $bindings = [])
+    {
+        $this->queries[] = ['sql' => $sql, 'bindings' => $bindings];
+        $row = $this->row;
+        return new class($row) {
+            private $row;
+            public function __construct($row)
+            {
+                $this->row = $row;
+            }
+            public function num_rows()
+            {
+                return empty($this->row) ? 0 : 1;
+            }
+            public function row_array()
+            {
+                return $this->row;
+            }
+        };
+    }
+}

--- a/src/public/tests/Unit/models/Model_quotes_ship_test.php
+++ b/src/public/tests/Unit/models/Model_quotes_ship_test.php
@@ -1,0 +1,56 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../Fakes/FakeDbHandler.php';
+require_once __DIR__ . '/../../Fakes/FakeQuotesDbHandler.php';
+
+class Model_quotes_ship_test extends TestCase
+{
+    private $model;
+
+    protected function setUp(): void
+    {
+        $CI = &get_instance();
+        $CI->load->model('Model_quotes_ship');
+        $this->model = $CI->Model_quotes_ship;
+    }
+
+    public function test_getQuoteShipByKey_returns_row_when_found()
+    {
+        $row = [
+            'id' => 1,
+            'marketplace' => 'AMZ',
+            'zip' => '12345678',
+            'sku' => '["sku1","sku2"]',
+            'cost' => '10.00'
+        ];
+        $fakeDb = new FakeQuotesDbHandler($row);
+        $this->model->db = $fakeDb;
+
+        $result = $this->model->getQuoteShipByKey('AMZ', '12345-678', ['sku2', 'sku1'], '10.00');
+
+        $this->assertEquals($row, $result);
+        $this->assertSame(['AMZ', '12345678', '["sku1","sku2"]', '10.00'], $fakeDb->queries[0]['bindings']);
+    }
+
+    public function test_getQuoteShipByKey_returns_false_when_not_found()
+    {
+        $fakeDb = new FakeQuotesDbHandler([]); // no row returned
+        $this->model->db = $fakeDb;
+
+        $result = $this->model->getQuoteShipByKey('AMZ', '12345-678', ['sku1'], '5');
+
+        $this->assertFalse($result);
+    }
+
+    public function test_getQuoteShipByKey_returns_false_with_empty_params()
+    {
+        $fakeDb = new FakeQuotesDbHandler([]);
+        $this->model->db = $fakeDb;
+
+        $result = $this->model->getQuoteShipByKey('', '', '', '');
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary
- add FakeQuotesDbHandler for simulating DB results
- test Model_quotes_ship::getQuoteShipByKey
- document manual steps for verifying quote lookup

## Testing
- `composer install --no-interaction` *(fails: PHP version requirement)*
- `vendor/bin/phpunit tests/Unit/models/Model_quotes_ship_test.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f48baa288328b08dbe03abe7775a