### PR TITLE
Ensure multiseller flag persists in CalculoFrete

### DIFF
--- a/src/public/application/libraries/CalculoFrete.php
+++ b/src/public/application/libraries/CalculoFrete.php
@@ -1188,6 +1188,9 @@ class CalculoFrete {
             }
         }
 
+        // Persistir flag para uso posterior
+        $this->enable_multiseller_operation = $enable_multiseller_operation;
+
         $this->setFieldSKUQuote($platform);
 
         // Se não passar zipcode, não precisa validar.
@@ -1399,7 +1402,7 @@ class CalculoFrete {
 
                 try {
                     $this->instanceLogistic('TableInternal', $storeId, $dataQuote, $logistic['seller']);
-                    $quoteResponse = $this->logistic->getQuote($dataQuote, false, $enable_multiseller_operation);
+                    $quoteResponse = $this->logistic->getQuote($dataQuote, false, $this->enable_multiseller_operation);
                 } catch (InvalidArgumentException $exception) {
                     $quoteResponse = array(
                         'success' => false,
@@ -2173,7 +2176,7 @@ class CalculoFrete {
         //Verificar pelo número da cotação, valor pago e sla.
         $selectedQuote = array();
 
-        if ($enable_multiseller_operation) {
+        if ($this->enable_multiseller_operation) {
             if (!empty($quoteResponse['data']['services'])) {
                 $price    = null;
                 $deadline = null;


### PR DESCRIPTION
## Summary
- assign result to `enable_multiseller_operation` property when computing multiseller status
- pass property to `logistic->getQuote()`
- use the property when evaluating multiseller blocks

## Testing
- `composer install` *(fails: PHP version incompatible)*
- `vendor/bin/phpunit --configuration phpunit.xml tests/Unit/CalculoFreteAggregationTest.php` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_687423772d788328a8a7b3bf03fd443a