### PR TITLE
Implement seller extraction from SKU

### DIFF
--- a/src/public/application/libraries/CalculoFrete.php
+++ b/src/public/application/libraries/CalculoFrete.php
@@ -3602,7 +3602,11 @@ class CalculoFrete {
      */
     private function extractSellerFromSku(string $sku): string
     {
-        // Código do método...
+        if (preg_match('/S(\d+)/', $sku, $matches)) {
+            return $matches[1];
+        }
+
+        return '';
     }
         /**
      * Verifica se execução paralela está disponível


### PR DESCRIPTION
## Summary
- add regex logic to parse the seller ID from SKU patterns such as `PROD123S1001`
- return empty string if the pattern is not found

## Testing
- `composer install --no-interaction --no-progress --ignore-platform-reqs`
- `./vendor/bin/phpunit -c phpunit.xml --stop-on-failure` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68742a1aef888328b6257d58e364a39c