### PR TITLE
Add validation and exception handling in quote logic

### DIFF
--- a/src/public/application/libraries/CalculoFrete.php
+++ b/src/public/application/libraries/CalculoFrete.php
@@ -3752,16 +3752,43 @@ class CalculoFrete {
             $logisticType = $integration ?: 'TableInternal';
             $freightSeller = $integration ? true : false;
 
-            $dataQuote = [
-                'zipcodeRecipient' => $zipcode,
-                'items'            => $items,
-            ];
+            if (is_array($this->validationResult) &&
+                isset(
+                    $this->validationResult['dataQuote'],
+                    $this->validationResult['cross_docking'],
+                    $this->validationResult['zipCodeSeller'],
+                    $this->validationResult['arrDataAd']
+                )) {
+                // Aproveita dados já validados na etapa inicial
+                $dataQuote = $this->validationResult['dataQuote'];
+                $dataQuote['crossDocking']  = $this->validationResult['cross_docking'];
+                $dataQuote['zipcodeSender'] = $this->validationResult['zipCodeSeller'];
+                $dataQuote['dataInternal']  = $this->validationResult['arrDataAd'];
+            } else {
+                $dataQuote = [
+                    'zipcodeRecipient' => $zipcode,
+                    'items'            => $items,
+                ];
+            }
 
             $result = null;
             try {
                 $this->instanceLogistic($logisticType, $storeId, $dataQuote, $freightSeller);
                 $logistic = $this->logistic;
                 $result = $logistic->getQuote($dataQuote, false);
+            } catch (InvalidArgumentException $e) {
+                get_instance()->log_data('batch', $log_name,
+                    'Falha de validação na cotação: ' . $e->getMessage(), 'E');
+
+                $executionTime = microtime(true) - $time_start;
+                return [
+                    'success' => false,
+                    'data' => [
+                        'message' => 'Erro na validação dos dados de cotação: ' . $e->getMessage(),
+                        'execution_time' => round($executionTime, 3),
+                        'execution_mode' => 'traditional_error'
+                    ]
+                ];
             } catch (Exception $e) {
                 get_instance()->log_data('batch', $log_name,
                     "Falha ao cotar com logística {$logisticType}: " . $e->getMessage(), 'E');
@@ -3776,6 +3803,19 @@ class CalculoFrete {
 
                     get_instance()->log_data('batch', $log_name,
                         'Fallback TableInternal executado', 'I');
+                } catch (InvalidArgumentException $fallbackException) {
+                    get_instance()->log_data('batch', $log_name,
+                        'Falha no fallback TableInternal: ' . $fallbackException->getMessage(), 'E');
+
+                    $executionTime = microtime(true) - $time_start;
+                    return [
+                        'success' => false,
+                        'data' => [
+                            'message' => 'Erro interno na cotação: ' . $fallbackException->getMessage(),
+                            'execution_time' => round($executionTime, 3),
+                            'execution_mode' => 'traditional_error'
+                        ]
+                    ];
                 } catch (Exception $fallbackException) {
                     get_instance()->log_data('batch', $log_name,
                         'Falha no fallback TableInternal: ' . $fallbackException->getMessage(), 'E');

--- a/src/public/application/libraries/Logistic/Intelipost_async.php
+++ b/src/public/application/libraries/Logistic/Intelipost_async.php
@@ -110,6 +110,14 @@ class Intelipost extends Logistic
      */
     public function getQuote(array $dataQuote, bool $moduloFrete = false): array
     {
+        if (!isset(
+            $dataQuote['zipcodeSender'],
+            $dataQuote['zipcodeRecipient'],
+            $dataQuote['items']
+        ) || !is_array($dataQuote['items'])) {
+            throw new InvalidArgumentException('Dados de cotação incompletos');
+        }
+
         $sales_channel = $this->sellerCenter;
         if (!$this->freightSeller) {
             $sales_channel .= "-$this->store";
@@ -131,6 +139,9 @@ class Intelipost extends Logistic
         );
 
         foreach ($dataQuote['items'] as $sku) {
+            if (!isset($sku['peso'], $sku['valor'], $sku['quantidade'], $sku['largura'], $sku['altura'], $sku['comprimento'], $sku['skuseller'], $sku['sku'])) {
+                throw new InvalidArgumentException('Item da cotação inválido');
+            }
             $dataProduct = array(
                 "weight"            => $sku['peso'],
                 "cost_of_goods"     => $sku['valor'] / $sku['quantidade'],


### PR DESCRIPTION
## Summary
- validate required fields at the beginning of `Intelipost_async::getQuote`
- check each item for missing keys
- catch `InvalidArgumentException` in `CalculoFrete` when quoting
- use previously validated data when invoking fallback quote

## Testing
- `composer install --ignore-platform-reqs` *(fails: composer.json not found)*
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: phpunit not installed)*
- `php -l src/public/application/libraries/CalculoFrete.php`


------
https://chatgpt.com/codex/tasks/task_e_68751745a6a08328b69364d17e44525e