### PR TITLE
Add partially invoiced status constant

### DIFF
--- a/src/public/application/language/portuguese_br/application_lang.php
+++ b/src/public/application/language/portuguese_br/application_lang.php
@@ -929,6 +929,7 @@ $lang['application_order_57'] = "Nota Fiscal Com Erro";
 $lang['application_order_58'] = "Aguardando Retirada";
 $lang['application_order_59'] = "Extravio/Devolução";
 $lang['application_order_60'] = "Entregue"; // Precisa de intervenção no Marketplace para avisar que foi entregue.
+$lang['application_order_62'] = "Faturado Parcialmente";
 $lang['application_order_70'] = "Troca de Vendedor";
 $lang['application_order_80'] = "Problema Contratação Frete";
 $lang['application_order_81'] = "Devolvido";

--- a/src/public/application/models/Model_orders.php
+++ b/src/public/application/models/Model_orders.php
@@ -3956,6 +3956,7 @@ class OrderStatusConst {
     const DEVOLUTION_IN_TRANSPORT = 59; // Em Transporte (Pedido com extravio/devolução ao rementente)
     const MISPLACEMENT_IN_TRANSPORT = 59; // Em Transporte (Pedido com extravio/devolução ao rementente)
     const DELIVERED_NOTIFY_MKTPLACE = 60; // Entregue (Avisar ao marketplace que foi entregue)
+    const PARTIALLY_INVOICED = 62; // Faturado Parcialmente
     const ERROR_FREIGHT_CONTRACTING = 80; // Problema na contratação do frete
     const CANCELLATION_REQUESTED = 90; // Solicitado Cancelamento
     const CANCELED_BY_SELLER = 95; // Cancelado Pelo Seller (Cancelado pelo vendedor)
@@ -4008,6 +4009,8 @@ class OrderStatusConst {
                 return "Em Transporte (Pedido com extravio/devolução ao rementente)";
             case self::DELIVERED_NOTIFY_MKTPLACE:
                 return "Entregue (Avisar ao marketplace que foi entregue)";
+            case self::PARTIALLY_INVOICED:
+                return "Faturado Parcialmente";
             case self::ERROR_FREIGHT_CONTRACTING:
                 return "Problema na contratação do frete";
             case self::CANCELLATION_REQUESTED:


### PR DESCRIPTION
## Summary
- add `PARTIALLY_INVOICED` status constant
- return 'Faturado Parcialmente' in `statusDescription`
- add Portuguese translation for new status

## Testing
- `composer test` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6875a88ecaac8328aeec8c44176907a7