### PR TITLE
Add partial invoice route

### DIFF
--- a/src/public/application/config/routes.php
+++ b/src/public/application/config/routes.php
@@ -151,3 +151,4 @@ $route['Api/V1/financeiro/legalpanel'] = 'Api/V1/financeiro/legalpanel/LegalPane
 $route['orderToDelivered'] = 'OrderToDelivered';
 $route['orderToDelivered/update'] = 'orderToDelivered/update';
 $route['orderToDelivered/getLojasByMarketplace'] = 'OrderToDelivered/getLojasByMarketplace';
+$route['orders/(:any)/partial-invoice'] = 'Api/V1/Orders/partial_invoice/$1';


### PR DESCRIPTION
## Summary
- add route for partial invoicing
- implement `partial_invoice_post` API method

## Testing
- `composer test` *(fails: configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6875aa54d2408328bb5bdebd678ee87e