### PR TITLE
Add invoice info per item

### DIFF
--- a/src/public/application/controllers/Api/V1/Orders.php
+++ b/src/public/application/controllers/Api/V1/Orders.php
@@ -860,6 +860,13 @@ class Orders extends API
         $resultPayment = $queryPayment->result_array();
         $resultHistoric = $queryHistoric->result_array();
 
+        $itemIds = array_column($resultOrder, 'iten_id');
+        $invoices = $this->model_nfes->getNfesDataByOrderItemIds($itemIds);
+        $invoiceByItem = [];
+        foreach ($invoices as $inv) {
+            $invoiceByItem[$inv['order_item_id']] = $inv;
+        }
+
         // Dados do pedido.
         $order = $resultOrder[0];
 
@@ -1061,9 +1068,19 @@ class Orders extends API
                 "sku_integration" => $sku_integration,
 				"campaigns" => $campaignArray,
 				"sku_marketplace" => $skumkt,
-				"return" => $returnArray,
+                "return" => $returnArray,
                 "order_item_id" => $this->changeType($iten['iten_id'], "int"),
             );
+
+            $inv = $invoiceByItem[$iten['iten_id']] ?? null;
+            $arrItems[$key]['invoice'] = $inv ? [
+                'date_emission' => $inv['date_emission'],
+                'value' => $this->changeType($inv['nfe_value'], 'float'),
+                'serie' => $this->changeType($inv['nfe_serie'], 'int'),
+                'num' => $this->changeType($inv['nfe_num'], 'int'),
+                'key' => $inv['chave'],
+                'link' => $inv['link_nfe']
+            ] : null;
 
             $commission_hierarchy_value = null;
             $commission_hierarchy_level = null;

--- a/src/public/application/models/Model_nfes.php
+++ b/src/public/application/models/Model_nfes.php
@@ -241,5 +241,17 @@ class Model_nfes extends CI_Model
         return $this->db->where_in('order_id', $order_id)->get('nfes')->result_array();
     }
 
+    public function getNfesDataByOrderItemIds(array $item_ids): array
+    {
+        if (empty($item_ids)) {
+            return [];
+        }
+
+        return $this->db
+            ->where_in('order_item_id', $item_ids)
+            ->get('nfes')
+            ->result_array();
+    }
+
 
 }

--- a/src/public/tests/Unit/models/Model_nfes_test.php
+++ b/src/public/tests/Unit/models/Model_nfes_test.php
@@ -1,0 +1,29 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/../../Fakes/FakeDbHandler.php';
+
+class Model_nfes_test extends TestCase
+{
+    private $model;
+
+    protected function setUp(): void
+    {
+        $CI = &get_instance();
+        $CI->load->model('Model_nfes');
+        $this->model = $CI->Model_nfes;
+        $this->model->db = new FakeDbHandler();
+    }
+
+    public function test_getNfesDataByOrderItemIds_returns_array()
+    {
+        $result = $this->model->getNfesDataByOrderItemIds([1, 2]);
+        $this->assertEquals([['mocked' => 'result']], $result);
+        $this->assertStringContainsString('order_item_id', $this->model->db->queries[0]['sql']);
+    }
+
+    public function test_getNfesDataByOrderItemIds_with_empty_returns_empty()
+    {
+        $result = $this->model->getNfesDataByOrderItemIds([]);
+        $this->assertEquals([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- fetch invoices by order item id
- inject invoice data per item in API
- test invoice lookup by order item id

## Testing
- `php -l src/public/application/models/Model_nfes.php`
- `php -l src/public/application/controllers/Api/V1/Orders.php`
- ❌ `phpunit --configuration src/public/phpunit.xml --filter Model_nfes_test` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6875ab666194832898302c2777e08d70