### PR TITLE
Fix partial shipping flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ edited through the administration panel or inserted manually during setup.
   ```json
   {"lowest_price": "Normal", "lowest_deadline": "Expressa"}
   ```
-* Feature flag `oep-2009-partial-invoicing` – enables partial invoicing and shipping
-  for multiseller orders. When disabled these operations are ignored.
+* Feature flag `oep-2009-partial-invoicing` – enables partial invoicing for
+  multiseller orders. When disabled this operation is ignored.
+* Feature flag `oep-2010-partial-shipping` – enables shipping notifications for
+  multiseller orders.
 
 When `multiseller_freight_results` is enabled the quote response is modified so
 that the cheapest option uses the name from `lowest_price` and the fastest uses

--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -1779,7 +1779,7 @@ private function executeNewMultisellerQuote(array $items, string $zipcode): ?arr
         
         try {
             // Verificar se feature flag está habilitada feature-OEP-2010-partial-shipping
-            if (!\App\Libraries\FeatureFlag\FeatureManager::isFeatureAvailable('oep-2009-partial-invoicing')) {
+            if (!\App\Libraries\FeatureFlag\FeatureManager::isFeatureAvailable('oep-2010-partial-shipping')) {
                 $this->log_data('batch', $log_name,
                     "Feature flag de envio parcial desabilitada - notificação ignorada", "W");
                 return ['success' => true, 'message' => 'Feature flag desabilitada'];

--- a/src/public/tests/Unit/IntegrationNotifyShippingTest.php
+++ b/src/public/tests/Unit/IntegrationNotifyShippingTest.php
@@ -1,0 +1,41 @@
+<?php
+use PHPUnit\Framework\TestCase;
+class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t="I"){} }
+use Tests\Fakes\FunctionMockTrait;
+
+require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+
+class IntegrationNotifyShippingTest extends TestCase
+{
+    use FunctionMockTrait;
+
+    public function test_notifyMarketplaceShipping_sends_request_when_flag_enabled()
+    {
+        \App\Libraries\FeatureFlag\FeatureManager::$client = new class {
+            public function isEnabled($name,$ctx=null){return $name==='oep-2010-partial-shipping';}
+        };
+
+        $integration = new class {
+            public $called = false;
+            public $data;
+            public function notifyShipping($api, $data){$this->called=true;$this->data=[$api,$data];return ['success'=>true];}
+        };
+
+        $controller = new class($integration) extends GetOrders {
+            public function __construct($integration){$this->integration=$integration;}
+            protected function log_data($m,$a,$v,$t='I'){}
+        };
+        $controller->api_keys = ['api_url'=>'http://localhost','access_token'=>'tk'];
+
+        $order = ['bill_no'=>'123','order_mkt_multiseller'=>'123','shipping_carrier'=>'C','service_method'=>'S'];
+        $ship = ['tracking_code'=>'TRK','shipping_carrier'=>'C','service_method'=>'S','shipping_date'=>'2020-01-01 00:00:00'];
+
+        $ref = new ReflectionClass(GetOrders::class);
+        $method = $ref->getMethod('notifyMarketplaceShipping');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($controller, [$order,$ship]);
+
+        $this->assertTrue($result['success']);
+        $this->assertTrue($integration->called, 'notifyShipping should be called');
+    }
+}


### PR DESCRIPTION
## Summary
- use the `oep-2010-partial-shipping` flag to control shipping notifications
- document the new flag in the README
- add a unit test for shipping notifications when the flag is enabled

## Testing
- `php -l src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php`
- `php -l src/public/tests/Unit/IntegrationNotifyShippingTest.php`
- `php src/public/system/libraries/Vendor/phpunit/phpunit/phpunit -c src/public/phpunit.xml tests/Unit/IntegrationNotifyShippingTest.php` *(fails: Cannot acquire reference to $GLOBALS)*

------
https://chatgpt.com/codex/tasks/task_e_68763cf435248328bffe73b59d0879b6