### PR TITLE
Fix financial trigger flag consistency

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -1899,7 +1899,7 @@ private function executeNewMultisellerQuote(array $items, string $zipcode): ?arr
         
         try {
             // Verificar se feature flag está habilitada feature-OEP-2012-financial-trigger
-            if (!\App\Libraries\FeatureFlag\FeatureManager::isFeatureAvailable('oep-1921-muiltiseller-freight-results')) {
+            if (!\App\Libraries\FeatureFlag\FeatureManager::isFeatureAvailable('feature-OEP-2012-financial-trigger')) {
                 return ['success' => false, 'message' => 'Feature flag desabilitada'];
             }
             

--- a/src/public/tests/Unit/FinancialTriggerTest.php
+++ b/src/public/tests/Unit/FinancialTriggerTest.php
@@ -1,0 +1,43 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+
+class FinancialTriggerTest extends TestCase
+{
+    public function test_trigger_financial_process_runs_when_flag_enabled()
+    {
+        \App\Libraries\FeatureFlag\FeatureManager::$client = new class {
+            public function isEnabled($name,$ctx=null){return $name==='feature-OEP-2012-financial-trigger';}
+        };
+
+        $CI = &get_instance();
+        $CI->model_orders = new class {
+            public function getOrdersByMultisellerNumber($num){return [['total_order'=>10]];}
+        };
+
+        $controller = new class extends GetOrders {
+            public function __construct() {}
+            protected function log_data($m,$a,$v,$t='I'){}
+            protected function isFirstDeliveryForMultisellerOrder(string $n): bool {return true;}
+            public function callShould(array $o){
+                $ref = new ReflectionClass(GetOrders::class);
+                $m = $ref->getMethod('shouldTriggerFinancialProcess');
+                $m->setAccessible(true);
+                return $m->invoke($this,$o);
+            }
+            public function callTrigger(array $o){
+                $ref = new ReflectionClass(GetOrders::class);
+                $m = $ref->getMethod('triggerFinancialProcessForFirstDelivery');
+                $m->setAccessible(true);
+                return $m->invoke($this,$o);
+            }
+        };
+
+        $order = ['order_mkt_multiseller'=>'GRP1','bill_no'=>'O1'];
+        $this->assertTrue($controller->callShould($order));
+        $result = $controller->callTrigger($order);
+        $this->assertTrue($result['success']);
+    }
+}


### PR DESCRIPTION
## Summary
- correct feature flag name used in GetOrders financial process
- add unit test for financial trigger when flag is enabled

## Testing
- `php -l src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php`
- `php -l src/public/tests/Unit/FinancialTriggerTest.php`
- `vendor/bin/phpunit tests/Unit/FinancialTriggerTest.php` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687657475c3c8328b6eb248764293e5a