### PR TITLE
Add OEP behaviour summary and placeholder tests

### DIFF
--- a/OEP_FEATURES.md
+++ b/OEP_FEATURES.md
@@ -1,0 +1,11 @@
+# Implemented OEP Behaviors
+
+This repository contains partial implementations for several Operational Excellence Proposals (OEP). Below is a brief description of the core behaviors covered by automated tests.
+
+- **OEP-2002** – When the feature flag `OEP-2002-permitir-criar-lojas-para-pessoas-fisicas` is enabled, store creation accepts personal documents (`cpf`/`rg`) instead of corporate (`cnpj`/`ie`).
+- **OEP-1957** – API endpoints for add-ons delegate operations to a new `handleRequest` method whenever the flag `OEP-1957-update-delete-publica-addon-occ` is active.
+- **OEP-1598** – Creating or updating recipients through the BACEN integration requires a VTEX seller identifier. If it is missing, the operation returns an empty response.
+- **OEP-1599** – VTEX simulation may include the seller identifier on `merchantName` when the setting `return_merchant_name_on_simulation_vtex` is active.
+- **OEP-1789** – The integration name `mevo` is treated as `vtex` internally, keeping behavior consistent between both channels.
+- **OEP-2010** – Partial shipping notifications are skipped when the feature `oep-2009-partial-invoicing` is disabled.
+- **OEP-2012** – A financial trigger runs on the first delivery of a multiseller order when the flag `feature-OEP-2012-financial-trigger` is enabled.

--- a/src/public/tests/Unit/OepFeaturesTest.php
+++ b/src/public/tests/Unit/OepFeaturesTest.php
@@ -1,0 +1,92 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+
+require_once APPPATH.'controllers/Api/V1/Stores.php';
+require_once APPPATH.'controllers/Api/V1/AddOn.php';
+require_once APPPATH.'controllers/Api/SellerCenter/Vtex/Simulation.php';
+require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+require_once APPPATH.'libraries/PagarmeLibrary.php';
+require_once APPPATH.'libraries/Integration_v2/Integration_v2.php';
+
+class OepFeaturesTest extends TestCase
+{
+    private function setFeature(string $name, bool $enabled)
+    {
+        \App\Libraries\FeatureFlag\FeatureManager::$client = new class($name, $enabled) {
+            private $name; private $enabled;
+            public function __construct($n,$e){$this->name=$n;$this->enabled=$e;}
+            public function isEnabled($name,$ctx=null){
+                return $name === $this->name ? $this->enabled : false;
+            }
+        };
+    }
+
+    private function callPrivate($obj,$method,$args=[]) {
+        $ref=new ReflectionClass($obj);$m=$ref->getMethod($method);$m->setAccessible(true);return $m->invokeArgs($obj,$args);
+    }
+
+    public function test_oep2002_validateCreate_switches_rules()
+    {
+        $this->setFeature('OEP-2002-permitir-criar-lojas-para-pessoas-fisicas', true);
+        $controller = new class extends Stores { public function __construct(){} };
+        $controller->insert = ['CNPJ'=>'123','inscricao_estadual'=>'1'];
+        $controller->errors = [];
+        $controller->validations = ['CNPJ'=>'check_cnpj','inscricao_estadual'=>'check_ie'];
+        $this->callPrivate($controller,'validateCreate',[true]);
+        $this->assertEquals(['check_cpf','check_rg'],$controller->validations);
+    }
+
+    public function test_oep1957_addon_calls_handleRequest()
+    {
+        $this->setFeature('OEP-1957-update-delete-publica-addon-occ', true);
+        $called=false;
+        $controller = new class($called) extends AddOn {
+            private $flag; public function __construct(& $f){$this->flag=&$f;}
+            protected function handleRequest($sku,$method){$this->flag=true;}
+        };
+        $controller->index_post('ABC');
+        $this->assertTrue($called);
+    }
+
+    public function test_oep1599_simulation_returns_merchant_name()
+    {
+        $simulation = new class extends Simulation { public function __construct(){parent::__construct();}}
+        ;
+        $this->assertTrue($this->callPrivate($simulation,'return_seller_id_on_merchant_name'));
+}
+
+    public function test_oep1789_mevo_mapped_to_vtex()
+    {
+        $integration = new class extends \App\Libraries\Integration_v2\Integration_v2 { public function __construct(){} };
+        $integration->setIntegration('mevo');
+        $this->assertSame('vtex', $this->callPrivate($integration, 'integration'));
+    }
+
+    public function test_oep2010_notifyMarketplaceShipping_respects_flag()
+    {
+        $this->setFeature('oep-2009-partial-invoicing', false);
+        $controller = new class extends GetOrders { public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} };
+        $result = $this->callPrivate($controller,'notifyMarketplaceShipping',[[],[]]);
+        $this->assertEquals('Feature flag desabilitada', $result['message']);
+    }
+
+    public function test_oep2012_shouldTriggerFinancialProcess()
+    {
+        $this->setFeature('feature-OEP-2012-financial-trigger', true);
+        $controller = new class extends GetOrders { public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} };
+        $controller->model_orders = new class {
+            public function getOrdersByMultisellerNumber($num){return [['paid_status'=>5],['paid_status'=>6]];}
+        };
+        $order = ['order_mkt_multiseller'=>'MS1'];
+        $this->assertTrue($this->callPrivate($controller,'shouldTriggerFinancialProcess',[$order]));
+    }
+    public function test_oep1598_recipient_bacen_requires_external_id()
+    {
+        $lib = new class extends PagarmeLibrary { public function __construct(){ $this->_CI = (object)["model_stores"=>new class{public function setDateUpdateNow($id){}},"logName"=>"" ]; } };
+        $store=["id"=>1,"agency"=>"1","account"=>"1","raz_social"=>"X","CNPJ"=>"1","bank_number"=>"1","phone_1"=>"(11)1111-1111"];
+        $result=$lib->createUpdateRecipientBacen_v5($store);
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- document behaviours of implemented OEPs
- add skeleton tests checking each feature flag

## Testing
- `vendor/bin/phpunit -d error_reporting=E_ALL\&~E_DEPRECATED tests/Unit/OepFeaturesTest.php` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68763cfc6e30832891bd0bb83cc7645e