### PR TITLE
Fix path for CalculoFrete test

### DIFF
--- a/src/public/tests/Unit/CalculoFreteFormatQuoteTest.php
+++ b/src/public/tests/Unit/CalculoFreteFormatQuoteTest.php
@@ -1,7 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../application/libraries/CalculoFrete.php';
+require_once __DIR__ . '/../../application/libraries/CalculoFrete.php';
 
 class CalculoFreteFormatQuoteTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- fix incorrect path in `CalculoFreteFormatQuoteTest`

## Testing
- `system/libraries/Vendor/bin/phpunit --no-configuration tests/Unit/CalculoFreteFormatQuoteTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6876ca35eed083289f40952e03f2e7d5