### PR TITLE
Expose PartialShipping route

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ edited through the administration panel or inserted manually during setup.
 * Setting `enable_multiple_returns_per_order` – when active the platform allows
   creating more than one return for a single order.
 * `POST /api/v1/partial-shipping` – placeholder endpoint for partial shipping
-  updates. It currently responds with a not implemented message while OEP‑2008
-  is under development.
+  updates. The route maps to `Api/V1/PartialShipping/index` and currently
+  responds with a not implemented message while OEP‑2008 is under development.
 
 When `multiseller_freight_results` is enabled the quote response is modified so
 that the cheapest option uses the name from `lowest_price` and the fastest uses

--- a/src/public/application/config/routes.php
+++ b/src/public/application/config/routes.php
@@ -152,3 +152,4 @@ $route['orderToDelivered'] = 'OrderToDelivered';
 $route['orderToDelivered/update'] = 'orderToDelivered/update';
 $route['orderToDelivered/getLojasByMarketplace'] = 'OrderToDelivered/getLojasByMarketplace';
 $route['orders/(:any)/partial-invoice'] = 'Api/V1/Orders/partial_invoice/$1';
+$route['api/v1/partial-shipping'] = 'Api/V1/PartialShipping/index_post';


### PR DESCRIPTION
## Summary
- wire POST `/api/v1/partial-shipping` to the placeholder controller
- clarify the placeholder endpoint in the README

## Testing
- `composer install --no-interaction --no-scripts --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6876ca3afd188328b25e47ab920d08a7