### PR TITLE
Add orders_invoices migration

### DIFF
--- a/src/public/application/migrations/20250701155000_create_orders_invoices.php
+++ b/src/public/application/migrations/20250701155000_create_orders_invoices.php
@@ -1,0 +1,42 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+return new class extends CI_Migration
+{
+    public function up()
+    {
+        if (!$this->db->table_exists('orders_invoices')) {
+            $this->dbforge->add_field([
+                'id' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'auto_increment' => TRUE,
+                ],
+                'order_id' => [
+                    'type' => 'INT',
+                    'constraint' => 11,
+                    'unsigned' => TRUE,
+                    'null' => FALSE,
+                ],
+                'invoice_value' => [
+                    'type' => 'DECIMAL',
+                    'constraint' => '10,2',
+                    'null' => FALSE,
+                ],
+                'invoice_date' => [
+                    'type' => 'DATETIME',
+                    'null' => FALSE,
+                ],
+            ]);
+            $this->dbforge->add_key('id', true);
+            $this->dbforge->create_table('orders_invoices', TRUE);
+            $this->db->query('ALTER TABLE `orders_invoices` ENGINE = InnoDB');
+            $this->db->query('ALTER TABLE `orders_invoices` ADD KEY `orders_invoices_order_id` (`order_id`)');
+        }
+    }
+
+    public function down()
+    {
+        $this->dbforge->drop_table('orders_invoices', TRUE);
+    }
+};


### PR DESCRIPTION
## Summary
- add `orders_invoices` table migration before invoice items migration

## Testing
- `./system/libraries/Vendor/bin/phpunit --version` *(fails: platform_check.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876d3351e808328a371508841c26465