### PR TITLE
Implement partial shipping endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ edited through the administration panel or inserted manually during setup.
   multiseller orders.
 * Setting `enable_multiple_returns_per_order` – when active the platform allows
   creating more than one return for a single order.
-* `POST /api/v1/partial-shipping` – placeholder endpoint for partial shipping
-  updates. The route maps to `Api/V1/PartialShipping/index` and currently
-  responds with a not implemented message while OEP‑2008 is under development.
+* `POST /api/v1/partial-shipping` – updates shipping information for multiseller
+  orders. The route maps to `Api/V1/PartialShipping/index` and calls the batch
+  process responsible for handling partial shipments.
 
 When `multiseller_freight_results` is enabled the quote response is modified so
 that the cheapest option uses the name from `lowest_price` and the fastest uses

--- a/src/public/application/controllers/Api/V1/PartialShipping.php
+++ b/src/public/application/controllers/Api/V1/PartialShipping.php
@@ -3,11 +3,52 @@ require APPPATH . "controllers/Api/V1/API.php";
 
 class PartialShipping extends API
 {
-    public function index_post()
+    /**
+     * Processa dados de envio parcial de pedidos multiseller.
+     * Opcionalmente recebe o payload para facilitar testes, caso
+     * nulo os dados serão lidos de php://input.
+     *
+     * @param array|null $payload
+     * @return array
+     */
+    public function index_post(array $payload = null)
     {
-        return [
-            'success' => false,
-            'message' => 'Partial shipping update not implemented'
+        if ($payload === null) {
+            $payload = json_decode(file_get_contents('php://input'), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return [
+                    'success' => false,
+                    'message' => 'JSON inválido'
+                ];
+            }
+        }
+
+        $required = ['bill_no', 'tracking_code', 'carrier', 'shipping_date'];
+        foreach ($required as $field) {
+            if (empty($payload[$field])) {
+                return [
+                    'success' => false,
+                    'message' => "Campo obrigatório: $field"
+                ];
+            }
+        }
+
+        $billNo = xssClean($payload['bill_no']);
+        $shippingData = [
+            'tracking_code' => xssClean($payload['tracking_code']),
+            'carrier' => xssClean($payload['carrier']),
+            'shipping_date' => xssClean($payload['shipping_date']),
         ];
+
+        if (!empty($payload['estimated_delivery'])) {
+            $shippingData['estimated_delivery'] = xssClean($payload['estimated_delivery']);
+        }
+
+        if (!class_exists('GetOrders')) {
+            require_once APPPATH . 'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+        }
+
+        $processor = new GetOrders();
+        return $processor->processPartialShipping($billNo, $shippingData);
     }
 }

--- a/src/public/tests/Unit/PartialShippingControllerTest.php
+++ b/src/public/tests/Unit/PartialShippingControllerTest.php
@@ -1,16 +1,46 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-define('BASEPATH', __DIR__);
+class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+
+class GetOrders extends BatchBackground_Controller {
+    public static $lastInstance;
+    public $received;
+    public function __construct(){self::$lastInstance=$this;}
+    public function processPartialShipping($billNo, array $data){
+        $this->received = [$billNo,$data];
+        return ['success'=>true,'tracking_code'=>$data['tracking_code']];
+    }
+}
+
 require_once APPPATH.'controllers/Api/V1/PartialShipping.php';
 
 class PartialShippingControllerTest extends TestCase
 {
-    public function test_index_post_returns_placeholder_message()
+    public function test_index_post_validates_fields()
     {
         $controller = new PartialShipping();
-        $result = $controller->index_post();
+        $result = $controller->index_post([]);
         $this->assertFalse($result['success']);
-        $this->assertEquals('Partial shipping update not implemented', $result['message']);
+        $this->assertStringContainsString('bill_no', $result['message']);
+    }
+
+    public function test_index_post_calls_batch_controller()
+    {
+        $controller = new PartialShipping();
+        $payload = [
+            'bill_no' => 'ORDER1',
+            'tracking_code' => 'TRK',
+            'carrier' => 'CARR',
+            'shipping_date' => '2020-01-01'
+        ];
+        $result = $controller->index_post($payload);
+        $this->assertTrue($result['success']);
+        $this->assertSame('TRK', $result['tracking_code']);
+        $this->assertSame(['ORDER1', [
+            'tracking_code' => 'TRK',
+            'carrier' => 'CARR',
+            'shipping_date' => '2020-01-01'
+        ]], GetOrders::$lastInstance->received);
     }
 }


### PR DESCRIPTION
## Summary
- implement processing logic in PartialShipping API
- document usage of the endpoint
- test PartialShipping controller

## Testing
- `src/public/system/libraries/Vendor/bin/phpunit --configuration src/public/phpunit.xml --verbose` *(fails: require platform_check.php)*

------
https://chatgpt.com/codex/tasks/task_e_6876e7cc4e2c83289593eae6c1c5292c