### PR TITLE
Fix path for CalculoFrete require_once

### DIFF
--- a/src/public/tests/Unit/CalculoFreteSellerIdMultisellerTest.php
+++ b/src/public/tests/Unit/CalculoFreteSellerIdMultisellerTest.php
@@ -1,6 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
-require_once __DIR__ . '/../application/libraries/CalculoFrete.php';
+require_once __DIR__ . '/../../application/libraries/CalculoFrete.php';
 
 class CalculoFreteSellerIdMultisellerTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- fix include path in `CalculoFreteSellerIdMultisellerTest`

## Testing
- `php -l tests/Unit/CalculoFreteSellerIdMultisellerTest.php`
- `composer test tests/Unit/CalculoFreteSellerIdMultisellerTest.php` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6876eba319608328ad3459aaca86e325