### PR TITLE
Fix helper class declarations in tests

### DIFF
--- a/src/public/tests/Unit/FinancialTriggerTest.php
+++ b/src/public/tests/Unit/FinancialTriggerTest.php
@@ -1,7 +1,9 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+}
 require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
 
 class FinancialTriggerTest extends TestCase

--- a/src/public/tests/Unit/IntegrationNotifyInvoicingTest.php
+++ b/src/public/tests/Unit/IntegrationNotifyInvoicingTest.php
@@ -1,6 +1,8 @@
 <?php
 use PHPUnit\Framework\TestCase;
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t="I"){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t="I"){} }
+}
 use Tests\Fakes\FunctionMockTrait;
 
 require_once APPPATH.'controllers/BatchC/Integration/Integration.php';

--- a/src/public/tests/Unit/IntegrationNotifyShippingTest.php
+++ b/src/public/tests/Unit/IntegrationNotifyShippingTest.php
@@ -1,6 +1,8 @@
 <?php
 use PHPUnit\Framework\TestCase;
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t="I"){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t="I"){} }
+}
 use Tests\Fakes\FunctionMockTrait;
 
 require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';

--- a/src/public/tests/Unit/OepFeaturesTest.php
+++ b/src/public/tests/Unit/OepFeaturesTest.php
@@ -1,7 +1,9 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+}
 
 require_once APPPATH.'controllers/Api/V1/Stores.php';
 require_once APPPATH.'controllers/Api/V1/AddOn.php';

--- a/src/public/tests/Unit/PartialInvoicingTest.php
+++ b/src/public/tests/Unit/PartialInvoicingTest.php
@@ -2,7 +2,9 @@
 use PHPUnit\Framework\TestCase;
 use Tests\Fakes\FunctionMockTrait;
 
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+}
 require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
 
 class PartialInvoicingTest extends TestCase

--- a/src/public/tests/Unit/PartialShippingControllerTest.php
+++ b/src/public/tests/Unit/PartialShippingControllerTest.php
@@ -1,7 +1,9 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+}
 
 class GetOrders extends BatchBackground_Controller {
     public static $lastInstance;


### PR DESCRIPTION
## Summary
- prevent duplicate helper class declarations in several unit tests

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --filter IntegrationNotifyInvoicingTest` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6876ed3a2ff48328a7855eeae764559a