### PR TITLE
Update invoicing to use order_item_id references

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -1634,7 +1634,11 @@ private function executeNewMultisellerQuote(array $items, string $zipcode): ?arr
                 foreach ($orderItems as $oi) {
                     $available = $oi['quantity'] - ($already[$oi['sku']] ?? 0);
                     if ($available > 0) {
-                        $invoiceItems[] = ['sku' => $oi['sku'], 'quantity' => $available, 'price' => $oi['price']];
+                        $invoiceItems[] = [
+                            'order_item_id' => $oi['id'],
+                            'qty_invoiced'  => $available,
+                            'price'         => $oi['price']
+                        ];
                         $invoiceValue += $oi['price'] * $available;
                     }
                 }
@@ -1659,7 +1663,11 @@ private function executeNewMultisellerQuote(array $items, string $zipcode): ?arr
                         continue;
                     }
 
-                    $invoiceItems[] = ['sku' => $item['sku'], 'quantity' => $qty, 'price' => $oi['price']];
+                    $invoiceItems[] = [
+                        'order_item_id' => $oi['id'],
+                        'qty_invoiced'  => $qty,
+                        'price'         => $oi['price']
+                    ];
                     $invoiceValue += $oi['price'] * $qty;
                 }
             }

--- a/src/public/application/models/Model_orders_invoice_items.php
+++ b/src/public/application/models/Model_orders_invoice_items.php
@@ -11,16 +11,20 @@ class Model_orders_invoice_items extends CI_Model
         if (empty($items)) {
             return false;
         }
+
+        // Items must contain invoice_id, order_item_id and qty_invoiced fields
         return $this->db->insert_batch('orders_invoice_items', $items);
     }
 
     public function getInvoicedQuantities(int $orderId): array
     {
-        $this->db->select('oii.sku, SUM(oii.quantity) as quantity');
+        $this->db->select('oi.sku, SUM(oii.qty_invoiced) as quantity');
         $this->db->from('orders_invoice_items oii');
-        $this->db->join('orders_invoices oi', 'oi.id = oii.invoice_id');
-        $this->db->where('oi.order_id', $orderId);
-        $this->db->group_by('oii.sku');
+        $this->db->join('orders_invoices inv', 'inv.id = oii.invoice_id');
+        $this->db->join('orders_item oi', 'oi.id = oii.order_item_id');
+        $this->db->where('inv.order_id', $orderId);
+        $this->db->group_by('oi.sku');
+
         return $this->db->get()->result_array();
     }
 }

--- a/src/public/tests/Unit/PartialInvoicingTest.php
+++ b/src/public/tests/Unit/PartialInvoicingTest.php
@@ -27,8 +27,8 @@ class PartialInvoicingTest extends TestCase
 
         $order = ['id'=>1,'bill_no'=>'ORDER1','order_mkt_multiseller'=>'ORDER1','total_order'=>100];
         $items = [
-            ['sku'=>'SKU1','price'=>10,'quantity'=>2],
-            ['sku'=>'SKU2','price'=>5,'quantity'=>1]
+            ['id'=>11,'sku'=>'SKU1','price'=>10,'quantity'=>2],
+            ['id'=>12,'sku'=>'SKU2','price'=>5,'quantity'=>1]
         ];
 
         $orderModel->expects($this->once())
@@ -46,7 +46,7 @@ class PartialInvoicingTest extends TestCase
             ->method('createInvoice')
             ->with(
                 $this->callback(function($data){return $data['invoice_value']==5;}),
-                [['sku'=>'SKU2','quantity'=>1,'price'=>5]]
+                [['order_item_id'=>12,'qty_invoiced'=>1,'price'=>5]]
             )
             ->willReturn(10);
         $orderModel->expects($this->once())
@@ -89,9 +89,8 @@ class PartialInvoicingTest extends TestCase
 
         $order = ['id'=>1,'bill_no'=>'ORDER1','order_mkt_multiseller'=>'ORDER1','total_order'=>100];
         $items = [
-            ['sku'=>'SKU1','price'=>10,'quantity'=>2],
-
-            ['sku'=>'SKU2','price'=>5,'quantity'=>1]
+            ['id'=>11,'sku'=>'SKU1','price'=>10,'quantity'=>2],
+            ['id'=>12,'sku'=>'SKU2','price'=>5,'quantity'=>1]
         ];
 
         $orderModel->expects($this->once())
@@ -106,8 +105,8 @@ class PartialInvoicingTest extends TestCase
             ->with(
                 $this->callback(function($data){return $data['invoice_value']==100;}),
                 [
-                    ['sku'=>'SKU1','quantity'=>2,'price'=>10],
-                    ['sku'=>'SKU2','quantity'=>1,'price'=>5]
+                    ['order_item_id'=>11,'qty_invoiced'=>2,'price'=>10],
+                    ['order_item_id'=>12,'qty_invoiced'=>1,'price'=>5]
                 ]
             )
             ->willReturn(10);


### PR DESCRIPTION
## Summary
- update `Model_orders_invoice_items` for new schema
- support new invoice item format in `Model_orders::createInvoice`
- generate invoice data using order item ids
- update unit tests for new fields

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `vendor/bin/phpunit` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6876ee789c1c832886d39ce8b38e70ab