### PR TITLE
Fix invoice variable name in partial invoicing

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -914,8 +914,8 @@ class GetOrders extends BatchBackground_Controller
             
 
             // Processar faturamento
-            $invoice = $this->generateInvoiceData($order, $items);
-            $invoiceId = $this->model_orders->createInvoice($invoice['data'], $invoice['items']);
+            $invoiceData = $this->generateInvoiceData($order, $items);
+            $invoiceId = $this->model_orders->createInvoice($invoiceData['data'], $invoiceData['items']);
 
             
             if (!$invoiceId) {
@@ -929,7 +929,7 @@ class GetOrders extends BatchBackground_Controller
             );
 
             // Notificar marketplace
-            $this->notifyMarketplaceInvoicing($order, $invoice['data']);
+            $this->notifyMarketplaceInvoicing($order, $invoiceData['data']);
             
             $this->log_data('batch', $log_name, "Faturamento parcial processado: $billNo", "I");
             


### PR DESCRIPTION
## Summary
- correct variable used when notifying marketplace in `processPartialInvoicing`

## Testing
- `composer install --ignore-platform-reqs`
- `vendor/bin/phpunit -c phpunit.xml tests/Unit/PartialInvoicingTest.php` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6876f11f900c832899238410e032f262