### PR TITLE
Fix Conectala controller class naming

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php
@@ -5,7 +5,7 @@ Realiza a integração com SellerCenter Conectala
 
 */   
 
-class Integration 
+class ConectalaIntegration
 {     
     public $url_api = '';
  

--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -5,8 +5,8 @@ Atualiza pedidos que chegaram na Novo Mundo SC
 
 */   
 
-// require 'Marketplace/Conectala/Integration.php';
-require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
+// require 'Marketplace/Conectala/ConectalaIntegration.php';
+require APPPATH . "controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php";
 
 /**
  * @property CI_Loader $load
@@ -85,7 +85,7 @@ class GetOrders extends BatchBackground_Controller
         $this->load->library('calculoFrete');
 
 
-		$this->integration = new Integration();
+        $this->integration = new ConectalaIntegration();
 	}
 
 	// php index.php BatchC/Marketplace/Conectala/GetOrders run null NM

--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/OrdersStatus.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/OrdersStatus.php
@@ -3,7 +3,7 @@
  * Atualiza os status dos pedidos nos sellerscenter do conecta lá
  * */
 
-require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
+require APPPATH . "controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php";
 
 /**
  * @property Model_orders $model_orders
@@ -27,7 +27,7 @@ class OrdersStatus extends BatchBackground_Controller
 	{
 		parent::__construct();
 
-		$this->integration = new Integration();
+                $this->integration = new ConectalaIntegration();
 
 		// carrega os modulos necessários para o Job
 		$this->load->model('model_orders');

--- a/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersStatus.php
+++ b/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersStatus.php
@@ -2,7 +2,7 @@
 /*
  * Atualiza os status dos pedidos nos sellerscenter do conecta lá
  * */
-require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
+require APPPATH . "controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php";
 
  class OccOrdersStatus extends BatchBackground_Controller 
 {
@@ -16,7 +16,7 @@ require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
 	{
 		parent::__construct();
 
-		$this->integration = new Integration();
+                $this->integration = new ConectalaIntegration();
 
 		// carrega os modulos necessários para o Job
 		$this->load->model('model_orders');

--- a/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersSync.php
+++ b/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersSync.php
@@ -2,7 +2,7 @@
 /*
  * Atualiza os status dos pedidos nos sellerscenter do conecta lá
  * */
-require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
+require APPPATH . "controllers/BatchC/Marketplace/Conectala/ConectalaIntegration.php";
 
  class OccOrdersSync extends BatchBackground_Controller 
 {
@@ -13,7 +13,7 @@ require APPPATH . "controllers/BatchC/Marketplace/Conectala/Integration.php";
 	{
 		parent::__construct();
 
-		$this->integration = new Integration();
+                $this->integration = new ConectalaIntegration();
 
 		// carrega os modulos necessários para o Job
 		$this->load->model('model_orders');


### PR DESCRIPTION
## Summary
- rename Integration controller to avoid duplicate class name
- update Conectala controllers to use the new class
- adjust OCC controllers for new integration name

## Testing
- `./src/public/system/libraries/Vendor/bin/phpunit -c src/public/phpunit.xml` *(fails: Cannot acquire reference to $GLOBALS)*

------
https://chatgpt.com/codex/tasks/task_e_687706b638588328a71bb98a9df4345c