### PR TITLE
Fix invoice item query in Model_nfes

### DIFF
--- a/src/public/application/models/Model_nfes.php
+++ b/src/public/application/models/Model_nfes.php
@@ -265,8 +265,12 @@ class Model_nfes extends CI_Model
         }
 
         return $this->db
-            ->where_in('order_item_id', $item_ids)
-            ->get('nfes')
+            ->select('nfes.*, oii.order_item_id')
+            ->from('orders_invoice_items oii')
+            ->join('orders_invoices oi', 'oi.id = oii.invoice_id')
+            ->join('nfes', 'nfes.order_id = oi.order_id')
+            ->where_in('oii.order_item_id', $item_ids)
+            ->get()
             ->result_array();
     }
 

--- a/src/public/tests/Fakes/FakeDbHandler.php
+++ b/src/public/tests/Fakes/FakeDbHandler.php
@@ -5,6 +5,41 @@ class FakeDbHandler
     public array $queries = [];
     public array $data = [];
 
+    public function select($fields)
+    {
+        $this->queries[] = ['sql' => 'select ' . $fields];
+        return $this;
+    }
+
+    public function from($table)
+    {
+        $this->queries[] = ['sql' => 'from ' . $table];
+        return $this;
+    }
+
+    public function join($table, $condition)
+    {
+        $this->queries[] = ['sql' => 'join ' . $table . ' on ' . $condition];
+        return $this;
+    }
+
+    public function where_in($field, $values)
+    {
+        $this->queries[] = ['sql' => 'where_in(' . $field . ')'];
+        return $this;
+    }
+
+    public function get()
+    {
+        $this->queries[] = ['sql' => 'get'];
+        return new class {
+            public function result_array()
+            {
+                return [['mocked' => 'result']];
+            }
+        };
+    }
+
     public function where($key, $value = null, $escape = null)
     {
         return $this;

--- a/src/public/tests/Unit/models/Model_nfes_test.php
+++ b/src/public/tests/Unit/models/Model_nfes_test.php
@@ -18,7 +18,14 @@ class Model_nfes_test extends TestCase
     {
         $result = $this->model->getNfesDataByOrderItemIds([1, 2]);
         $this->assertEquals([['mocked' => 'result']], $result);
-        $this->assertStringContainsString('order_item_id', $this->model->db->queries[0]['sql']);
+        $containsJoin = false;
+        foreach ($this->model->db->queries as $query) {
+            if (strpos($query['sql'], 'orders_invoice_items') !== false) {
+                $containsJoin = true;
+                break;
+            }
+        }
+        $this->assertTrue($containsJoin);
     }
 
     public function test_getNfesDataByOrderItemIds_with_empty_returns_empty()

--- a/src/public/tests/bootstrap.php
+++ b/src/public/tests/bootstrap.php
@@ -4,6 +4,7 @@ $autoload = __DIR__ . '/../vendor/autoload.php';
 if (file_exists($autoload)) {
     require_once $autoload;
 }
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 define('ENVIRONMENT', 'testing');
 $_SERVER['CI_ENV'] = 'testing';


### PR DESCRIPTION
## Summary
- join invoice tables in `Model_nfes::getNfesDataByOrderItemIds`
- extend `FakeDbHandler` with basic query builder helpers
- check invoice item join in tests
- silence PHP deprecation notices for tests

## Testing
- `./vendor/bin/phpunit tests/Unit/models/Model_nfes_test.php --bootstrap tests/bootstrap.php --debug`

------
https://chatgpt.com/codex/tasks/task_e_6877ce328bb483289d8ec71094fe6ca6