### PR TITLE
Fix invalid JSON handling for Conectala orders

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -405,6 +405,10 @@ class GetOrders extends BatchBackground_Controller
         if ($order['http_code'] == 200) {
             $content = json_decode($order['content'], true);
 
+            if (!is_array($content) || json_last_error() !== JSON_ERROR_NONE) {
+                throw new Exception("Resposta inválida ao consultar o pedido {$line_item['order_code']}");
+            }
+
             if (!$content['success']) {
                 throw new Exception($content['message'] ?? "Não foi possível consultar o pedido {$line_item['order_code']}");
             }

--- a/src/public/tests/Unit/GetOrdersInvalidJsonTest.php
+++ b/src/public/tests/Unit/GetOrdersInvalidJsonTest.php
@@ -1,0 +1,37 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+if (!class_exists('BatchBackground_Controller')) {
+    class BatchBackground_Controller {public function __construct(){} protected function log_data($m,$a,$v,$t='I'){} }
+}
+
+require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+
+class GetOrdersInvalidJsonTest extends TestCase
+{
+    public function test_processOrder_throws_exception_on_invalid_json()
+    {
+        $integration = new class {
+            public function getOrderItem($api, $code)
+            {
+                return ['http_code' => 200, 'content' => '{invalid'];
+            }
+        };
+
+        $controller = new class($integration) extends GetOrders {
+            public function __construct($integration) { $this->integration = $integration; }
+            protected function log_data($m,$a,$v,$t='I'){}
+        };
+
+        $controller->api_keys = [];
+        $line = ['order_code' => '123', 'paid_status' => 1, 'new_order' => false];
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Resposta inválida ao consultar o pedido 123');
+
+        $ref = new ReflectionClass(GetOrders::class);
+        $method = $ref->getMethod('processOrder');
+        $method->setAccessible(true);
+        $method->invoke($controller, $line);
+    }
+}


### PR DESCRIPTION
## Summary
- validate JSON response before accessing
- throw exception on invalid order JSON
- test exception thrown when Conectala returns malformed JSON

## Testing
- `./vendor/bin/phpunit -c phpunit.xml tests/Unit/GetOrdersInvalidJsonTest.php` *(fails: PHPUnit Framework ExceptionWrapper due to deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6877d1d44b2c83289635afe0e5f429a4