### PR TITLE
Declare integration property

### DIFF
--- a/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersSync.php
+++ b/src/public/application/controllers/BatchC/SellerCenter/OCC/OccOrdersSync.php
@@ -8,6 +8,7 @@ require APPPATH . "controllers/BatchC/Marketplace/Conectala/ConectalaIntegration
 {
 
     public $int_to 	= '';
+    protected $integration = null;
 
 	public function __construct()
 	{


### PR DESCRIPTION
## Summary
- define `$integration` property on `OccOrdersSync`

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6877d1d87e84832888bf871613061315