### PR TITLE
Add multi-store support for fake orders

### DIFF
--- a/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
+++ b/src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php
@@ -197,13 +197,6 @@ class GetOrders extends BatchBackground_Controller
                 $store_id = $integration_last_post['store_id'];
             }
 
-            if ($store_id != $integration_last_post['store_id'] && !$this->enable_multiseller_operation) {
-                $message = "Pedido $orderMarketplace com produtos de lojas diferente lojas=($store_id e {$integration_last_post['store_id']}). Cancelar Pedido.";
-                echo "$message\n";
-                $this->log_data('batch ',$log_name, $message, "E");
-
-                throw new Exception($message);
-            }
         }
 
         if ($store_id === null) {

--- a/src/public/tests/Unit/GetOrdersStoreIdTest.php
+++ b/src/public/tests/Unit/GetOrdersStoreIdTest.php
@@ -1,0 +1,22 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once APPPATH.'controllers/BatchC/Marketplace/Conectala/GetOrders.php';
+
+class GetOrdersStoreIdTest extends TestCase
+{
+    private function callPrivate($obj,$method,$args=[]) {
+        $ref = new ReflectionClass($obj); $m=$ref->getMethod($method); $m->setAccessible(true); return $m->invokeArgs($obj,$args);
+    }
+
+    public function test_validarItensPedido_allows_different_stores()
+    {
+        $controller = new class extends GetOrders {
+            public function __construct(){}
+            protected function log_data($m,$a,$v,$t='I'){}
+            protected function validarItemPedido(array $i, string $o): array { return ['store_id'=>$i['store_id']]; }
+        };
+        $items = [['store_id'=>1], ['store_id'=>2]];
+        $store = $this->callPrivate($controller,'validarItensPedido',[$items,'O1']);
+        $this->assertEquals(1,$store);
+    }
+}


### PR DESCRIPTION
## Summary
- allow order creation with multiple stores per form line
- keep store info per product row
- generate hidden store_id inputs on submit
- group items by store when creating orders
- relax batch GetOrders store validation
- test that GetOrders accepts items from different stores

## Testing
- `php -l src/public/application/controllers/Orders.php`
- `php -l src/public/application/controllers/BatchC/Marketplace/Conectala/GetOrders.php`
- `vendor/bin/phpunit --configuration src/public/phpunit.xml tests/Unit/GetOrdersStoreIdTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877e97538208328871b39441f558837