### PR TITLE
Add logs directory initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,9 @@ ENV PATH=$PATH:/root/composer/vendor/bin \
 # Adiciona as configs.
 COPY ./nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./supervisor/supervisord.conf /etc/supervisord.conf
-
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Inicia o supervisor para rodar NGINX e PHP-FPM.
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+LOG_DIR=/var/www/html/public/application/logs
+mkdir -p "$LOG_DIR"
+chown www-data:www-data "$LOG_DIR"
+chmod 775 "$LOG_DIR"
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/src/public/.gitignore
+++ b/src/public/.gitignore
@@ -3,6 +3,7 @@
 application/config/config.php
 application/config/database.php
 application/logs/
+!application/logs/.gitkeep
 assets/images/catalog_product_image/
 assets/images/company_image/
 assets/images/etiquetas/


### PR DESCRIPTION
## Summary
- ensure `src/public/application/logs` is tracked in git
- add startup entrypoint that sets up logs directory
- copy entrypoint in Dockerfile

## Testing
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_68783440f96083288e2702c3a4b23347