### PR TITLE
Fix duplicated lines in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,75 +13,33 @@ for ENTRY in "${ENTRIES[@]}"; do
     fi
 done
 
-echo 
-
-if [ ! -d "public" ]; then
-	echo "Clonando repositório..."
-	cd src
-	git clone "$REPO"
-	mv Fase1 public
-
-	cd ../#!/bin/bash
-
-HOSTS_FILE="/mnt/c/Windows/System32/drivers/etc/hosts"
-ENTRIES=("127.0.0.1 minio.local" "127.0.0.1 mysql")
-REPO="https://github.com/ConectaLa/Fase1.git"
-
-# Adiciona entradas ao arquivo de hosts do Windows
-for ENTRY in "${ENTRIES[@]}"; do
-    if ! grep -Fxq "$ENTRY" "$HOSTS_FILE"; then
-        echo "Adicionando '$ENTRY' aos hosts..."
-        echo "$ENTRY" | sudo tee -a "$HOSTS_FILE" > /dev/null
-    else
-        echo "Entry '$ENTRY' já existe."
-    fi
-done
-
 echo
 
-# Clonagem e organização dos arquivos
-if [ ! -d "public" ]; then
+if [ ! -d "src/public" ]; then
     echo "Clonando repositório..."
+    mkdir -p src
     cd src
     git clone "$REPO"
     mv Fase1 public
-    rm -rf Fase1  # ← remove a pasta original após mover
-    cd ../
-
+    rm -rf Fase1
+    cd ..
     echo "Copiando arquivos da pasta files/ para src/public/"
     cp -a files/. src/public/
-else
-    cd ../
 fi
 
-# 🔧 Restaura permissões de execução para arquivos que precisam
+# Restores executable permissions
 echo "Restaurando permissões executáveis para arquivos críticos..."
 
 chmod +x \
-src/public/system/core/LaravelLikeUtils/var-dumper/Resources/bin/var-dump-server \
-src/public/system/libraries/Vendor/paragonie/random_compat/build-phar.sh
+    src/public/system/core/LaravelLikeUtils/var-dumper/Resources/bin/var-dump-server \
+    src/public/system/libraries/Vendor/paragonie/random_compat/build-phar.sh
 
-# Aplica permissão +x a todos arquivos .sh (opcional e seguro)
 find src/public -type f -name "*.sh" -exec chmod +x {} +
 
 echo
-echo "🧹 Limpando arquivos temporários..."
+echo "\xF0\x9F\xA7\xB9 Limpando arquivos temporários..."
 find . -type f -name "*Zone.Identifier*" -exec rm -f {} +
 
 echo
-echo "🚀 Iniciando containers..."
-docker-compose up -d
-
-
-	cp -a files/. src/public/
-else
-	cd ../
-fi
-
-echo
-echo "Limpando arquivos temporários."
-find . -type f -name "*Zone.Identifier*" -exec rm -f {} +
-
-echo
-echo "Iniciando containers..."
+echo "\xF0\x9F\x9A\x80 Iniciando containers..."
 docker-compose up -d


### PR DESCRIPTION
## Summary
- clean up setup.sh to remove duplicated logic
- ensure repo clone and permissions run only once

## Testing
- `bash -n setup.sh`
- `shellcheck setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_687834438ce48328997402416171760b