### PR TITLE
Fix BASEPATH redefinition in CalculoFreteAggregationTest

### DIFF
--- a/src/public/tests/Unit/CalculoFreteAggregationTest.php
+++ b/src/public/tests/Unit/CalculoFreteAggregationTest.php
@@ -1,6 +1,6 @@
 <?php
 use PHPUnit\Framework\TestCase;
-define('BASEPATH', __DIR__);
+defined('BASEPATH') || define('BASEPATH', __DIR__);
 require_once __DIR__ . '/../../application/libraries/CalculoFrete.php';
 
 class CalculoFreteAggregationTest extends TestCase


### PR DESCRIPTION
## Summary
- prevent double definition of BASEPATH in CalculoFreteAggregationTest

## Testing
- `composer install --no-interaction` *(fails: PHP version constraint)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687938c7f6048328b4fc54099960f45b