### PR TITLE
Fix test aliasing

### DIFF
--- a/src/public/tests/Unit/PartialShippingControllerTest.php
+++ b/src/public/tests/Unit/PartialShippingControllerTest.php
@@ -15,7 +15,9 @@ class FakeGetOrders extends BatchBackground_Controller {
     }
 }
 
-class_alias(FakeGetOrders::class, 'GetOrders');
+if (!class_exists('GetOrders', false)) {
+    class_alias(FakeGetOrders::class, 'GetOrders');
+}
 
 require_once APPPATH.'controllers/Api/V1/PartialShipping.php';
 


### PR DESCRIPTION
## Summary
- replace unconditional `class_alias` call with a class-existence check

## Testing
- `phpunit` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6879490ca2888328991a4b685e91bd05