### PR TITLE
Fix logging when marketplace info is missing

### DIFF
--- a/src/public/application/controllers/Api/FreteConectalaMarketplace.php
+++ b/src/public/application/controllers/Api/FreteConectalaMarketplace.php
@@ -206,7 +206,10 @@ class FreteConectalaMarketplace extends FreteConectala
      */
     private function returnError(string $message)
     {
-        $this->log_data('api', "frete{$this->mkt['channel']}", $message, 'E');
+        $channel = is_array($this->mkt) && array_key_exists('channel', $this->mkt)
+            ? $this->mkt['channel']
+            : 'unknown';
+        $this->log_data('api', "frete{$channel}", $message, 'E');
 
         $returnError = $this->getMessageError();
 


### PR DESCRIPTION
## Summary
- avoid undefined index when `$this->mkt` doesn't have `channel`
- adjust returnError() logging

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `php vendor/phpunit/phpunit/phpunit -c phpunit.xml` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6879575ffd6483289924c73603644568