### PR TITLE
Add default crossDocking key

### DIFF
--- a/src/public/application/libraries/CalculoFrete.php
+++ b/src/public/application/libraries/CalculoFrete.php
@@ -3798,6 +3798,7 @@ class CalculoFrete {
                 $dataQuote = [
                     'zipcodeRecipient' => $zipcode,
                     'items'            => $items,
+                    'crossDocking'     => 0,
                 ];
             }
 


### PR DESCRIPTION
## Summary
- ensure crossDocking key exists when building dataQuote

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: The configuration file does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68795fb87e888328acb8da379eb04ff9